### PR TITLE
Enable webhooks when using a reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@
 N8N_ENCRYPTION_KEY=super-secret-key
 N8N_USER_MANAGEMENT_JWT_SECRET=even-more-secret
 
+# If running locally and you need webhooks, set the public webhook URL here (from your reverse proxy server).
+# Example: https://ngrok-subdomain.ngrok-free.app/
+N8N_WEBHOOK_URL=
+
 
 ############
 # Supabase Secrets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ x-n8n: &service-n8n
     - N8N_PERSONALIZATION_ENABLED=false
     - N8N_ENCRYPTION_KEY
     - N8N_USER_MANAGEMENT_JWT_SECRET
+    - WEBHOOK_URL=${N8N_WEBHOOK_URL}
 
 x-ollama: &service-ollama
   image: ollama/ollama:latest


### PR DESCRIPTION
Enables webhooks when running locally.

Slightly related to https://github.com/coleam00/local-ai-packaged/issues/19, but without adding out-of-box ngrok support.

n8n docs: https://docs.n8n.io/hosting/configuration/configuration-examples/webhook-url/

## Tests

### Leaving N8N_WEBHOOK_URL blank

Results:

* Can access n8n via http://localhost:5678
* Cannot setup Telegram

### Setting N8N_WEBHOOK_URL to a publicly accessible URL

Setup:

1. `ngrok http http://localhost:5678`
2. In .env, set `N8N_WEBHOOK_URL=https://<ngrok_ephemeral_domain>/`

Results:

* Can still access n8n via http://localhost:5678
* Can successfully receive posts from Telegram
