### PR TITLE
Fix docker orphan warnings, hanging localai_default network and ollama containers, and optimize start time through dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,10 +254,10 @@ To update all containers to their latest versions (n8n, Open WebUI, etc.), run t
 
 ```bash
 # Stop all services
-docker compose -p localai -f docker-compose.yml -f supabase/docker/docker-compose.yml down
+docker compose -p localai -f docker-compose.yml --profile <your-profile> down
 
 # Pull latest versions of all containers
-docker compose -p localai -f docker-compose.yml -f supabase/docker/docker-compose.yml pull
+docker compose -p localai -f docker-compose.yml --profile <your-profile> pull
 
 # Start services again with your desired profile
 python start_services.py --profile <your-profile>
@@ -266,6 +266,7 @@ python start_services.py --profile <your-profile>
 Replace `<your-profile>` with one of: `cpu`, `gpu-nvidia`, `gpu-amd`, or `none`.
 
 Note: The `start_services.py` script itself does not update containers - it only restarts them or pulls them if you are downloading these containers for the first time. To get the latest versions, you must explicitly run the commands above.
+Note: Adding `--profile <your-profile>` to the docker compose commands ensure proper shutdown of the ollama containers, disposal of the `localai_default` network as well as update of the ollama docker images.
 
 ## Troubleshooting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - ./supabase/docker/docker-compose.yml
+ 
 volumes:
   n8n_storage:
   ollama_storage:
@@ -79,6 +82,10 @@ services:
       - "n8n import:credentials --separate --input=/backup/credentials && n8n import:workflow --separate --input=/backup/workflows"
     volumes:
       - ./n8n/backup:/backup  
+    depends_on:
+      # Wait for supabase postgres to be ready.
+      db:
+        condition: service_healthy          
 
   n8n:
     <<: *service-n8n
@@ -93,6 +100,12 @@ services:
     depends_on:
       n8n-import:
         condition: service_completed_successfully
+      # Wait for supabase postgres to be ready.
+      db:
+        condition: service_healthy    
+      # Wait for qdrant to be ready.
+      qdrant:
+        condition: service_healthy          
 
   qdrant:
     image: qdrant/qdrant
@@ -102,6 +115,14 @@ services:
       - 6333:6333
     volumes:
       - qdrant_storage:/qdrant/storage
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - bash -c '</dev/tcp/localhost/6333' || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 15s  
 
   caddy:
     container_name: caddy

--- a/start_services.py
+++ b/start_services.py
@@ -46,27 +46,21 @@ def prepare_supabase_env():
     print("Copying .env in root to .env in supabase/docker...")
     shutil.copyfile(env_example_path, env_path)
 
-def stop_existing_containers():
+def stop_existing_containers(profile=None):
     """Stop and remove existing containers for our unified project ('localai')."""
     print("Stopping and removing existing containers for the unified project 'localai'...")
-    run_command([
-        "docker", "compose",
-        "-p", "localai",
+    cmd = ["docker", "compose", "-p", "localai"]
+    if profile and profile != "none":
+        cmd.extend(["--profile", profile])
+    cmd.extend([
         "-f", "docker-compose.yml",
-        "-f", "supabase/docker/docker-compose.yml",
         "down"
     ])
-
-def start_supabase():
-    """Start the Supabase services (using its compose file)."""
-    print("Starting Supabase services...")
-    run_command([
-        "docker", "compose", "-p", "localai", "-f", "supabase/docker/docker-compose.yml", "up", "-d"
-    ])
+    run_command(cmd)
 
 def start_local_ai(profile=None):
     """Start the local AI services (using its compose file)."""
-    print("Starting local AI services...")
+    print("Starting all local AI services...")
     cmd = ["docker", "compose", "-p", "localai"]
     if profile and profile != "none":
         cmd.extend(["--profile", profile])
@@ -226,16 +220,9 @@ def main():
     generate_searxng_secret_key()
     check_and_fix_docker_compose_for_searxng()
     
-    stop_existing_containers()
-    
-    # Start Supabase first
-    start_supabase()
-    
-    # Give Supabase some time to initialize
-    print("Waiting for Supabase to initialize...")
-    time.sleep(10)
-    
-    # Then start the local AI services
+    stop_existing_containers(args.profile)
+   
+    # Start all  local AI services
     start_local_ai(args.profile)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses the following items:
### `warning msg=Found orphan containers`
* Fixed both when running the `start_services.py` script with no container running and with containers already running
* Symptoms:
```
Running: docker compose -p localai --profile cpu -f docker-compose.yml up -d
time="2025-03-25T11:17:09-06:00" level=warning msg="Found orphan containers ([supabase-storage supabase-edge-functions supabase-auth supabase-kong supabase-rest supabase-meta supabase-studio supabase-pooler realtime-dev.supabase-realtime supabase-analytics supabase-db supabase-vector supabase-imgproxy]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up."
```
```
Running: docker compose -p localai -f supabase/docker/docker-compose.yml up -d
time="2025-03-25T11:19:33-06:00" level=warning msg="Found orphan containers ([ollama-pull-llama ollama]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up."
```
* Fixed by including the supabase docker-compose file using the `include` top level element instead of using multiple `-f` arguments in the docker compose commands.
* This allowed for proper dependencies checking and removing the 10 second delay

### `localai_default` network not releases and `ollama` containers still running when running `docker compose down` command 
* Symptoms:
```
 ! Network localai_default                   Resource is still in use                                                                0.0s 
```
* Fixed by adding the `--profile` to the docker down command in the `start_services.py` script and in the documentation
* I think PR #7 is attempting to do some of the cleanup caused by this issue. Using `--profile` prevents the issue for happening and not clean up needed. 

###  `ollama` containers not updated when running `docker compose pull` command 
* Symptoms: no ollama container displayed in the list when running the pull command

* Fixed by adding the --profile to the docker pull command in the documentation

@coleam00 , I had to include one of the health checks from my other PR #34 since I added a dependency from n8n on qdrand and a health check was needed for that. I don't think it should but hope it doesn't create a conflict when you merge the two PRs but something to look out for.