### PR TITLE
fix(start_services): clean up startup process by including Supabase compose and improving container handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,10 @@ To update all containers to their latest versions (n8n, Open WebUI, etc.), run t
 
 ```bash
 # Stop all services
-docker compose -p localai --profile <your-profile> -f docker-compose.yml -f supabase/docker/docker-compose.yml down
+docker compose -p localai -f docker-compose.yml --profile <your-profile> down
 
 # Pull latest versions of all containers
-docker compose -p localai --profile <your-profile> -f docker-compose.yml -f supabase/docker/docker-compose.yml pull
+docker compose -p localai -f docker-compose.yml --profile <your-profile> pull
 
 # Start services again with your desired profile
 python start_services.py --profile <your-profile>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - ./supabase/docker/docker-compose.yml
+
 volumes:
   n8n_storage:
   ollama_storage:

--- a/start_services.py
+++ b/start_services.py
@@ -46,16 +46,13 @@ def prepare_supabase_env():
     print("Copying .env in root to .env in supabase/docker...")
     shutil.copyfile(env_example_path, env_path)
 
-def stop_existing_containers():
-    """Stop and remove existing containers for our unified project ('localai')."""
+def stop_existing_containers(profile=None):
     print("Stopping and removing existing containers for the unified project 'localai'...")
-    run_command([
-        "docker", "compose",
-        "-p", "localai",
-        "-f", "docker-compose.yml",
-        "-f", "supabase/docker/docker-compose.yml",
-        "down"
-    ])
+    cmd = ["docker", "compose", "-p", "localai"]
+    if profile and profile != "none":
+        cmd.extend(["--profile", profile])
+    cmd.extend(["-f", "docker-compose.yml", "down"])
+    run_command(cmd)
 
 def start_supabase():
     """Start the Supabase services (using its compose file)."""
@@ -226,7 +223,7 @@ def main():
     generate_searxng_secret_key()
     check_and_fix_docker_compose_for_searxng()
     
-    stop_existing_containers()
+    stop_existing_containers(args.profile)
     
     # Start Supabase first
     start_supabase()


### PR DESCRIPTION
## fix: clean up startup process by including Supabase compose and improving container handling

### Extended Description
- Use `include:` in `docker-compose.yml` to properly merge Supabase services into the main project.
- Update `start_services.py` to pass `--profile` during container shutdown, preventing orphan containers and stuck networks.
- Update README upgrade instructions to reflect these improvements.
- This fixes orphan containers, stuck `localai_default` network, and incomplete Ollama container updates.

This change ensures **clean startup/shutdown cycles**, **correct container management**, and **better reliability** without increasing complexity.

> [!NOTE]
> This PR is intentionally atomic and scoped only to fixing startup and container lifecycle issues.

## Problem before this PR

```bash
Starting Supabase services...
Running: docker compose -p localai -f supabase/docker/docker-compose.yml up -d
WARN[0000] Found orphan containers ([ollama ollama-pull-llama]) for this project...

Starting local AI services...
Running: docker compose -p localai --profile gpu-nvidia -f docker-compose.yml up -d
WARN[0000] Found orphan containers ([supabase-storage supabase-studio supabase-meta supabase-kong supabase-rest ...]) for this project...
```

## Result after this PR

✅ No orphan container warnings  
✅ Clean shutdown and restart cycles  
✅ No dangling `localai_default` network  
✅ Ollama containers properly updated and visible
