### PR TITLE
updated docker compose to use env for postgres + added .gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,7 @@ ENCRYPTION_KEY=generate-with-openssl # generate via `openssl rand -hex 32`
 POSTGRES_HOST=db
 POSTGRES_DB=postgres
 POSTGRES_PORT=5432
+POSTGRES_USER=postgres
 # default user is postgres
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+supabase

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,9 +272,9 @@ services:
       timeout: 3s
       retries: 10
     environment:
-      POSTGRES_USER: postgres
+      POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: postgres
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - 127.0.0.1:5433:5432
     volumes:


### PR DESCRIPTION
Problem:
- .env has POSTGRES_DB but not used
- .env does not have POSTGRES_USER

Fix:
- added POSTGRES_USER in .env.example
- added support for POSTGRES_DB and POSTGRES_USER in docker-compose.yml

Additions:
- added .gitignore for .env and supabase folder since those should never go into this repo.