### PR TITLE
searxng restart problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+supabase

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,8 +133,8 @@ services:
       - SEARXNG_HOSTNAME=${SEARXNG_HOSTNAME:-":8006"}
       - LANGFUSE_HOSTNAME=${LANGFUSE_HOSTNAME:-":8007"}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL:-internal}
-    cap_drop:
-      - ALL
+    # cap_drop:
+      # - ALL  # Temporarily commented out for first run
     cap_add:
       - NET_BIND_SERVICE
     logging:
@@ -272,9 +272,9 @@ services:
       timeout: 3s
       retries: 10
     environment:
-      POSTGRES_USER: postgres
+      POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: postgres
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - 127.0.0.1:5433:5432
     volumes:
@@ -287,8 +287,8 @@ services:
     restart: unless-stopped  
     volumes:
       - valkey-data:/data
-    cap_drop:
-      - ALL
+    # cap_drop:
+      # - ALL  # Temporarily commented out for first run
     cap_add:
       - SETGID
       - SETUID
@@ -316,8 +316,8 @@ services:
       - SEARXNG_BASE_URL=https://${SEARXNG_HOSTNAME:-localhost}/
       - UWSGI_WORKERS=${SEARXNG_UWSGI_WORKERS:-4}
       - UWSGI_THREADS=${SEARXNG_UWSGI_THREADS:-4}
-    cap_drop:
-      - ALL
+    # cap_drop:
+      # - ALL  # Temporarily commented out for first run
     cap_add:
       - CHOWN
       - SETGID

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -1,0 +1,15 @@
+# see https://docs.searxng.org/admin/settings/settings.html#settings-use-default-settings
+use_default_settings: true
+server:
+  # base_url is defined in the SEARXNG_BASE_URL environment variable, see .env and docker-compose.yml
+  secret_key: "070b432daf6a1faaa97f48c46ef4382677578a601314f8466ab84beeec06dfb8"  # change this!
+  limiter: false
+  image_proxy: true
+ui:
+  static_use_hash: true
+redis:
+  url: redis://redis:6379/0
+search:
+    formats:
+        - html
+        - json

--- a/searxng/uwsgi.ini
+++ b/searxng/uwsgi.ini
@@ -1,0 +1,55 @@
+[uwsgi]
+# Listening address
+# default value: [::]:8080 (see Dockerfile)
+http-socket = $(BIND_ADDRESS)
+
+# Who will run the code
+uid = searxng
+gid = searxng
+
+# Number of workers (usually CPU count)
+# default value: %k (= number of CPU core, see Dockerfile)
+workers = $(UWSGI_WORKERS)
+
+# Number of threads per worker
+# default value: 4 (see Dockerfile)
+threads = $(UWSGI_THREADS)
+
+# The right granted on the created socket
+chmod-socket = 666
+
+# Plugin to use and interpreter config
+single-interpreter = true
+master = true
+lazy-apps = true
+enable-threads = true
+
+# Module to import
+module = searx.webapp
+
+# Virtualenv and python path
+pythonpath = /usr/local/searxng/
+chdir = /usr/local/searxng/searx/
+
+# automatically set processes name to something meaningful
+auto-procname = true
+
+# Disable request logging for privacy
+disable-logging = true
+log-5xx = true
+
+# Set the max size of a request (request-body excluded)
+buffer-size = 8192
+
+# No keep alive
+# See https://github.com/searx/searx-docker/issues/24
+add-header = Connection: close
+
+# Follow SIGTERM convention
+# See https://github.com/searxng/searxng/issues/3427
+die-on-term
+
+# uwsgi serves the static files
+static-map = /static=/usr/local/searxng/searx/static
+static-gzip-all = True
+offload-threads = %k


### PR DESCRIPTION
Problem:
- searxng was not able to start properly due to trying to create config files
- the log recorded permission issue with creating uwsgi.ini and also settings.yml

Solution:
- This is most likely a permission issue?  Anyway, dropping cap_drop provides more permissions for the container...
- I encountered this on an ubuntu and popos machine - so the problem could be specific to OS