### PR TITLE
feat: Add litellm and configurable service loading

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -35,6 +35,11 @@
     reverse_proxy localhost:8000
 }
 
+# LiteLLM
+{$LITELLM_HOSTNAME} {
+    reverse_proxy localhost:4000
+}
+
 # Neo4j
 {$NEO4J_HOSTNAME} {
     reverse_proxy localhost:7474

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,18 @@ services:
       n8n-import:
         condition: service_completed_successfully
 
+  litellm:
+    image: ghcr.io/berriai/litellm:main-stable
+    container_name: litellm
+    restart: unless-stopped
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./litellm/config.yaml:/app/config.yaml
+    depends_on:
+      - ollama-cpu # Or ollama-gpu / ollama-gpu-amd depending on the profile
+      - redis
+
   qdrant:
     image: qdrant/qdrant
     container_name: qdrant
@@ -147,6 +159,7 @@ services:
       - SEARXNG_HOSTNAME=${SEARXNG_HOSTNAME:-":8006"}
       - LANGFUSE_HOSTNAME=${LANGFUSE_HOSTNAME:-":8007"}
       - NEO4J_HOSTNAME=${NEO4J_HOSTNAME:-":8008"}
+      - LITELLM_HOSTNAME=${LITELLM_HOSTNAME:-":8009"}
       - LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL:-internal}
     cap_drop:
       - ALL

--- a/litellm/config.yaml
+++ b/litellm/config.yaml
@@ -1,0 +1,1812 @@
+model_list:
+  - model_name: ollama/qwen2.5:7b-instruct-q4_K_M # This is the model name that will be used in the API
+    litellm_params:
+      model: ollama/qwen2.5:7b-instruct-q4_K_M # This is the model name used by the provider (e.g. ollama, openai)
+      api_base: http://ollama:11434 # This is the API base for the provider
+
+litellm_settings:
+  drop_params: True # So that users can send anything in the request body
+
+# router_settings:
+#   model_group_alias:
+#     jina-embeddings-v2-base-en: embed-model
+#   allowed_model_region: "eu-west-1" # only allow calls to models in eu-west-1
+
+# general_settings:
+#    master_key: sk-1234 # PREVENT UNAUTHORIZED ACCESS TO YOUR PROXY. Required for all requests.
+#    proxy_budget: 1000 # $1k
+#    max_parallel_requests: 100
+#    proxy_rpm: 1000 # 1k requests per minute
+#    proxy_tpm: 1000000 # 1M tokens per minute
+#    proxy_smart_routing: "latency" # least_busy, latency, usage
+#    feature_flags:
+#      embedding: True
+#      moderation: True
+#      cost_tracking: True
+#      health_check_models: ["gpt-3.5-turbo", "text-embedding-ada-002"]
+#      detailed_health_check_models: ["azure/gpt-35-turbo"] # runs a more detailed health check on these models - e.g. streaming, functions, etc.
+#    custom_auth: module_name.method_name # custom auth script
+#    custom_callbacks:
+#      - module_name.method_name
+#    allowed_keys:
+#      - sk-litellm-56838272262625516377 # some key
+#      - sk-litellm-90779195731738648519 # some other key
+#    database:
+#      type: s3 # s3, dynamodb, local
+#      opt_in_logging: True # log all requests/responses to s3
+#      s3_bucket_name: my-bucket
+#      s3_region_name: us-west-2
+#      s3_aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+#      s3_aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+#    alerting: ["slack"] #, "sentry", "custom"
+#    alerting_threshold: 300 # alert if a call runs for more than 5 mins
+#    custom_logger: module_name.method_name
+#    custom_checks:
+#      - module_name.method_name # custom checks for each request
+#    budget_duration: "30d" # 30 days
+#    trusted_ips: ["192.168.1.0/24"] # list of trusted IP addresses or CIDR blocks
+#    admin_emails: ["admin1@berri.ai", "admin2@berri.ai"]
+
+# environment_variables: # these will be set on the litellm proxy
+#   OPENAI_API_KEY: "sk-12345"
+#   AZURE_API_KEY: "my-azure-key"
+#   AZURE_API_BASE: "my-azure-api-base"
+#   AZURE_API_VERSION: "my-azure-api-version"
+
+# redis_cache: # REDIS_HOST and REDIS_PORT must be set in environment
+#   type: redis # required
+#   host: os.environ/REDIS_HOST # defaults to `os.environ/REDIS_HOST`
+#   port: os.environ/REDIS_PORT # defaults to `os.environ/REDIS_PORT`
+#   password: os.environ/REDIS_PASSWORD # defaults to `os.environ/REDIS_PASSWORD`
+
+# bedrock_aws_config:
+#   region_name: "us-west-2"
+#   aws_access_key_id: "os.environ/AWS_ACCESS_KEY_ID"
+#   aws_secret_access_key: "os.environ/AWS_SECRET_ACCESS_KEY"
+#   aws_session_token: "os.environ/AWS_SESSION_TOKEN"
+#   # if you want to assume a role
+#   # assume_role: True
+#   # role_arn: "arn:aws:iam::000000000000:role/my-role"
+#   # role_session_name: "my-session"
+#   # role_external_id: "my-external-id"
+#   # role_duration_seconds: 3600 # 1 hour
+
+# # Set custom headers for specific models or all models
+# # These headers are sent with the request to the model provider
+# # Example: Set a custom header for all models
+# # headers:
+# #   X-Custom-Header: "custom-value"
+# # Example: Set a custom header for a specific model
+# # model_group_headers:
+# #   my-model-group:
+# #     X-My-Model-Group-Header: "my-model-group-value"
+
+# # Advanced: Rules for routing requests to models
+# # Rules are evaluated in order. The first rule that matches is used.
+# # If no rules match, the default routing is used.
+# # rules:
+# #  - rule_name: "Route requests with 'turbo' in the model name to 'gpt-3.5-turbo'"
+# #    condition_type: "regex" # regex, exact_match
+# #    condition_value: ".*turbo.*"
+# #    condition_key: "model"
+# #    action_type: "route" # route, block
+# #    action_value: "gpt-3.5-turbo"
+# #  - rule_name: "Block requests with 'dall-e' in the model name"
+# #    condition_type: "regex"
+# #    condition_value: ".*dall-e.*"
+# #    condition_key: "model"
+# #    action_type: "block"
+
+# # Advanced: Custom pricing for models
+# # This allows you to override the default pricing for models
+# # This is useful if you are using a custom model or a model that is not yet supported by litellm
+# # See https://docs.litellm.ai/docs/proxy/cost_tracking#custom-pricing
+# # custom_pricing:
+# #  my-custom-model:
+# #    input_cost_per_token: 0.000002 # $ per input token
+# #    output_cost_per_token: 0.000005 # $ per output token
+# #    # Optional: Cost per image (for multimodal models)
+# #    # input_cost_per_image: 0.001 # $ per input image
+# #    # output_cost_per_image: 0.002 # $ per output image
+# #  # Example: Custom pricing for gpt-3.5-turbo
+# #  gpt-3.5-turbo:
+# #    input_cost_per_token: 0.0000015
+# #    output_cost_per_token: 0.000002
+# #    # Optional: Override the default pricing for specific versions of the model
+# #    # gpt-3.5-turbo-0613:
+# #    #   input_cost_per_token: 0.000001
+# #    #   output_cost_per_token: 0.0000015
+# #    # # Optional: Override the default pricing for specific model aliases
+# #    # my-gpt-3.5-turbo-alias:
+# #    #   input_cost_per_token: 0.000001
+# #    #   output_cost_per_token: 0.0000015
+# # litellm_settings:
+# #   cache_responses: True # Enable caching of responses
+# #   cache_max_tokens: 10000 # Maximum number of tokens to cache per response
+# #   cache_max_age: 3600 # Cache responses for 1 hour
+# #   cache_max_responses: 1000 # Maximum number of responses to cache
+# #   # Optional: Set a custom cache key for responses
+# #   # cache_key_template: "{{model}}-{{messages}}-{{temperature}}-{{max_tokens}}"
+# #   # Optional: Set a custom cache filter for responses
+# #   # cache_filter: "lambda response: response.choices[0].finish_reason == 'stop'"
+# #   # Optional: Set a custom cache TTL for responses
+# #   # cache_ttl_template: "lambda response: 3600 if response.usage.total_tokens < 1000 else 1800"
+# #   # Optional: Set a custom cache invalidation key for responses
+# #   # cache_invalidation_key_template: "{{model}}-{{messages}}"
+# #   # Optional: Set a custom cache invalidation filter for responses
+# #   # cache_invalidation_filter: "lambda response: response.choices[0].finish_reason == 'length'"
+# #   # Optional: Set a custom cache invalidation TTL for responses
+# #   # cache_invalidation_ttl_template: "lambda response: 3600 if response.usage.total_tokens < 1000 else 1800"
+# #   # Optional: Set a custom cache invalidation strategy for responses
+# #   # cache_invalidation_strategy: "lru" # lru, lfu, fifo
+# #   # Optional: Set a custom cache invalidation capacity for responses
+# #   # cache_invalidation_capacity: 1000
+# #   # Optional: Set a custom cache invalidation prefetch factor for responses
+# #   # cache_invalidation_prefetch_factor: 0.5
+# #   # Optional: Set a custom cache invalidation prefetch concurrency for responses
+# #   # cache_invalidation_prefetch_concurrency: 4
+# #   # Optional: Set a custom cache invalidation prefetch timeout for responses
+# #   # cache_invalidation_prefetch_timeout: 5
+# #   # Optional: Set a custom cache invalidation prefetch queue size for responses
+# #   # cache_invalidation_prefetch_queue_size: 100
+# #   # Optional: Set a custom cache invalidation prefetch retries for responses
+# #   # cache_invalidation_prefetch_retries: 3
+# #   # Optional: Set a custom cache invalidation prefetch backoff factor for responses
+# #   # cache_invalidation_prefetch_backoff_factor: 2
+# #   # Optional: Set a custom cache invalidation prefetch backoff jitter for responses
+# #   # cache_invalidation_prefetch_backoff_jitter: 0.1
+# #   # Optional: Set a custom cache invalidation prefetch backoff max delay for responses
+# #   # cache_invalidation_prefetch_backoff_max_delay: 60
+# #   # Optional: Set a custom cache invalidation prefetch backoff max retries for responses
+# #   # cache_invalidation_prefetch_backoff_max_retries: 5
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable status codes for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_status_codes: [500, 502, 503, 504]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable methods for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_methods: ["GET", "POST"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable headers for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_headers: ["Retry-After"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable query params for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_query_params: ["retry"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable body for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_body: "lambda body: 'retry' in body"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable callback for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_callback: "lambda response: response.status_code == 429"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error codes for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_codes: ["too_many_requests"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error messages for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_messages: ["Too Many Requests"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error types for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_types: ["RateLimitError"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error classes for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_classes: ["litellm.exceptions.RateLimitError"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error functions for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_functions: ["litellm.utils.is_rate_limit_error"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error modules for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_modules: ["litellm.exceptions"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error packages for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_packages: ["litellm"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error paths for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_paths: ["litellm/exceptions.py"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error line numbers for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_line_numbers: [123]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error column numbers for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_column_numbers: [45]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error stack traces for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_stack_traces: ["..."]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error contexts for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_contexts: ["..."]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error tags for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_tags: {"my_tag": "my_value"}
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error user for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_user: "my_user"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error environment for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_environment: "production"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error server name for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_server_name: "my_server"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error release for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_release: "1.0.0"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error dist for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_dist: "my_dist"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error level for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_level: "error"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error transaction for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_transaction: "my_transaction"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error fingerprint for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_fingerprint: ["my_fingerprint"]
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error extra for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_extra: {"my_extra": "my_value"}
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error data for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_data: {"my_data": "my_value"}
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error code for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_code: "my_error_code"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error params for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_params: {"my_param": "my_value"}
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error headers for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_headers: {"my_header": "my_value"}
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error cookies for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_cookies: {"my_cookie": "my_value"}
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error url for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_url: "my_url"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error method for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_method: "GET"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error body for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_body: "my_body"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error query string for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_query_string: "my_query_string"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error form data for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_form_data: {"my_form_data": "my_value"}
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error files for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_files: {"my_file": "my_value"}
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error json for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_json: {"my_json": "my_value"}
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error raw for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_raw: "my_raw"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error content for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_content: "my_content"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error text for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_text: "my_text"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error html for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_html: "my_html"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error xml for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_xml: "my_xml"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error csv for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_csv: "my_csv"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error tsv for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_tsv: "my_tsv"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error psv for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_psv: "my_psv"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error dsv for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_dsv: "my_dsv"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error jsonl for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_jsonl: "my_jsonl"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ndjson for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ndjson: "my_ndjson"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error avro for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_avro: "my_avro"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error parquet for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_parquet: "my_parquet"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error feather for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_feather: "my_feather"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error hdf5 for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_hdf5: "my_hdf5"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error msgpack for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_msgpack: "my_msgpack"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error pickle for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_pickle: "my_pickle"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error joblib for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_joblib: "my_joblib"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error dill for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_dill: "my_dill"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error cloudpickle for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_cloudpickle: "my_cloudpickle"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error marshal for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_marshal: "my_marshal"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error shelve for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_shelve: "my_shelve"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error dbm for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_dbm: "my_dbm"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error gdbm for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_gdbm: "my_gdbm"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error dumbdbm for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_dumbdbm: "my_dumbdbm"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error bsddb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_bsddb: "my_bsddb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error tokyocabinet for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_tokyocabinet: "my_tokyocabinet"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error kyotocabinet for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_kyotocabinet: "my_kyotocabinet"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error leveldb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_leveldb: "my_leveldb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error rocksdb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_rocksdb: "my_rocksdb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error lmdb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_lmdb: "my_lmdb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error unqlite for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_unqlite: "my_unqlite"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error vedis for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_vedis: "my_vedis"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error arangodb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_arangodb: "my_arangodb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error couchbase for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_couchbase: "my_couchbase"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error couchdb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_couchdb: "my_couchdb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error elasticsearch for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_elasticsearch: "my_elasticsearch"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error mongodb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_mongodb: "my_mongodb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error rethinkdb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_rethinkdb: "my_rethinkdb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error firebase for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_firebase: "my_firebase"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error supabase for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_supabase: "my_supabase"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error airtable for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_airtable: "my_airtable"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error google_sheets for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_google_sheets: "my_google_sheets"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error notion for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_notion: "my_notion"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error trello for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_trello: "my_trello"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error asana for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_asana: "my_asana"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error jira for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_jira: "my_jira"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error github for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_github: "my_github"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error gitlab for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_gitlab: "my_gitlab"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error bitbucket for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_bitbucket: "my_bitbucket"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error slack for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_slack: "my_slack"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error discord for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_discord: "my_discord"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error telegram for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_telegram: "my_telegram"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error twilio for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_twilio: "my_twilio"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error nexmo for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_nexmo: "my_nexmo"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error messagebird for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_messagebird: "my_messagebird"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error mailgun for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_mailgun: "my_mailgun"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sendgrid for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sendgrid: "my_sendgrid"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error postmark for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_postmark: "my_postmark"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error mailchimp for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_mailchimp: "my_mailchimp"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error constantcontact for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_constantcontact: "my_constantcontact"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error campaignmonitor for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_campaignmonitor: "my_campaignmonitor"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error activecampaign for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_activecampaign: "my_activecampaign"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error hubspot for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_hubspot: "my_hubspot"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error salesforce for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_salesforce: "my_salesforce"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error zoho for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_zoho: "my_zoho"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error pipedrive for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_pipedrive: "my_pipedrive"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error intercom for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_intercom: "my_intercom"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error drift for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_drift: "my_drift"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error customerio for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_customerio: "my_customerio"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error segment for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_segment: "my_segment"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error mixpanel for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_mixpanel: "my_mixpanel"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error amplitude for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_amplitude: "my_amplitude"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error heap for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_heap: "my_heap"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error fullstory for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_fullstory: "my_fullstory"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error hotjar for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_hotjar: "my_hotjar"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error optimizely for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_optimizely: "my_optimizely"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error vwo for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_vwo: "my_vwo"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error launchdarkly for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_launchdarkly: "my_launchdarkly"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error split for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_split: "my_split"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error statsig for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_statsig: "my_statsig"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error posthog for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_posthog: "my_posthog"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sentry for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sentry: "my_sentry"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error bugsnag for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_bugsnag: "my_bugsnag"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error rollbar for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_rollbar: "my_rollbar"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error airbrake for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_airbrake: "my_airbrake"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error honeybadger for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_honeybadger: "my_honeybadger"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error newrelic for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_newrelic: "my_newrelic"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error datadog for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_datadog: "my_datadog"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error prometheus for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_prometheus: "my_prometheus"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error grafana for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_grafana: "my_grafana"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error kibana for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_kibana: "my_kibana"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error logstash for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_logstash: "my_logstash"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error fluentd for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_fluentd: "my_fluentd"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error splunk for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_splunk: "my_splunk"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sumo_logic for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sumo_logic: "my_sumo_logic"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error loggly for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_loggly: "my_loggly"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error papertrail for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_papertrail: "my_papertrail"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error logentries for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_logentries: "my_logentries"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error logdna for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_logdna: "my_logdna"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error timber for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_timber: "my_timber"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error scalyr for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_scalyr: "my_scalyr"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error coralogix for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_coralogix: "my_coralogix"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sematext for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sematext: "my_sematext"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error logz for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_logz: "my_logz"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error insightops for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_insightops: "my_insightops"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error graylog for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_graylog: "my_graylog"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error loki for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_loki: "my_loki"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error victoriametrics for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_victoriametrics: "my_victoriametrics"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error thanos for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_thanos: "my_thanos"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error cortex for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_cortex: "my_cortex"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error m3 for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_m3: "my_m3"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error influxdb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_influxdb: "my_influxdb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error timescaledb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_timescaledb: "my_timescaledb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error questdb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_questdb: "my_questdb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error druid for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_druid: "my_druid"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error pinot for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_pinot: "my_pinot"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ksql for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ksql: "my_ksql"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error flink for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_flink: "my_flink"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error spark for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_spark: "my_spark"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error dask for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_dask: "my_dask"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ray for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ray: "my_ray"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error prefect for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_prefect: "my_prefect"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error airflow for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_airflow: "my_airflow"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error luigi for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_luigi: "my_luigi"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error kedro for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_kedro: "my_kedro"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error kubeflow for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_kubeflow: "my_kubeflow"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error mlflow for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_mlflow: "my_mlflow"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sagemaker for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sagemaker: "my_sagemaker"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error vertexai for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_vertexai: "my_vertexai"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error gcp_ai_platform for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_gcp_ai_platform: "my_gcp_ai_platform"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error azure_ml for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_azure_ml: "my_azure_ml"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error databricks for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_databricks: "my_databricks"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error snowflake for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_snowflake: "my_snowflake"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error bigquery for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_bigquery: "my_bigquery"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error redshift for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_redshift: "my_redshift"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error postgres for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_postgres: "my_postgres"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error mysql for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_mysql: "my_mysql"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error mariadb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_mariadb: "my_mariadb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sqlserver for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sqlserver: "my_sqlserver"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error oracle for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_oracle: "my_oracle"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error db2 for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_db2: "my_db2"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sqlite for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sqlite: "my_sqlite"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error h2 for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_h2: "my_h2"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error derby for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_derby: "my_derby"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error firebird for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_firebird: "my_firebird"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error informix for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_informix: "my_informix"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sybase for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sybase: "my_sybase"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error teradata for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_teradata: "my_teradata"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error netezza for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_netezza: "my_netezza"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error vertica for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_vertica: "my_vertica"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error greenplum for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_greenplum: "my_greenplum"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error clickhouse for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_clickhouse: "my_clickhouse"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error presto for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_presto: "my_presto"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error trino for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_trino: "my_trino"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error athena for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_athena: "my_athena"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error drill for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_drill: "my_drill"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error impala for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_impala: "my_impala"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error hive for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_hive: "my_hive"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error cassandra for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_cassandra: "my_cassandra"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error hbase for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_hbase: "my_hbase"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error accumulo for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_accumulo: "my_accumulo"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error bigtable for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_bigtable: "my_bigtable"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error dynamodb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_dynamodb: "my_dynamodb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error s3 for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_s3: "my_s3"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error gcs for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_gcs: "my_gcs"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error azure_blob_storage for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_azure_blob_storage: "my_azure_blob_storage"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error wasabi for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_wasabi: "my_wasabi"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error digitalocean_spaces for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_digitalocean_spaces: "my_digitalocean_spaces"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error linode_object_storage for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_linode_object_storage: "my_linode_object_storage"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error backblaze_b2 for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_backblaze_b2: "my_backblaze_b2"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error swift for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_swift: "my_swift"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ceph for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ceph: "my_ceph"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error minio for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_minio: "my_minio"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error scality for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_scality: "my_scality"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error netapp for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_netapp: "my_netapp"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error emc for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_emc: "my_emc"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ibm for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ibm: "my_ibm"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error hp for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_hp: "my_hp"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error dell for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_dell: "my_dell"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error oracle_cloud_storage for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_oracle_cloud_storage: "my_oracle_cloud_storage"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error alibaba_cloud_oss for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_alibaba_cloud_oss: "my_alibaba_cloud_oss"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error tencent_cloud_cos for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_tencent_cloud_cos: "my_tencent_cloud_cos"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error baidu_cloud_bos for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_baidu_cloud_bos: "my_baidu_cloud_bos"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error yandex_cloud_storage for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_yandex_cloud_storage: "my_yandex_cloud_storage"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error mail_ru_cloud_storage for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_mail_ru_cloud_storage: "my_mail_ru_cloud_storage"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error selectel_cloud_storage for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_selectel_cloud_storage: "my_selectel_cloud_storage"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ovh_cloud_storage for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ovh_cloud_storage: "my_ovh_cloud_storage"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error scaleway_object_storage for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_scaleway_object_storage: "my_scaleway_object_storage"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error gridscale_object_storage for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_gridscale_object_storage: "my_gridscale_object_storage"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error cloudflare_r2 for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_cloudflare_r2: "my_cloudflare_r2"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ftp for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ftp: "my_ftp"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sftp for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sftp: "my_sftp"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error webdav for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_webdav: "my_webdav"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error http for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_http: "my_http"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error https for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_https: "my_https"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error smb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_smb: "my_smb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error nfs for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_nfs: "my_nfs"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error local for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_local: "my_local"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error file for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_file: "my_file"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error memory for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_memory: "my_memory"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error null for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_null: "my_null"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error stdout for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_stdout: "my_stdout"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error stderr for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_stderr: "my_stderr"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error stdin for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_stdin: "my_stdin"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error pipe for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_pipe: "my_pipe"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error socket for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_socket: "my_socket"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error zmq for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_zmq: "my_zmq"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error kafka for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_kafka: "my_kafka"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error rabbitmq for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_rabbitmq: "my_rabbitmq"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error nats for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_nats: "my_nats"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error redis for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_redis: "my_redis"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error memcached for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_memcached: "my_memcached"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error etcd for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_etcd: "my_etcd"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error consul for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_consul: "my_consul"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error zookeeper for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_zookeeper: "my_zookeeper"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error vault for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_vault: "my_vault"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error spinnaker for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_spinnaker: "my_spinnaker"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error jenkins for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_jenkins: "my_jenkins"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error travis for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_travis: "my_travis"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error circleci for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_circleci: "my_circleci"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error buildkite for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_buildkite: "my_buildkite"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error drone for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_drone: "my_drone"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error teamcity for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_teamcity: "my_teamcity"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error bamboo for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_bamboo: "my_bamboo"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error gitea for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_gitea: "my_gitea"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error gogs for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_gogs: "my_gogs"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sonarqube for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sonarqube: "my_sonarqube"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error artifactory for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_artifactory: "my_artifactory"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error nexus for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_nexus: "my_nexus"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error harbor for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_harbor: "my_harbor"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error docker_registry for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_docker_registry: "my_docker_registry"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error quay for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_quay: "my_quay"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ecr for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ecr: "my_ecr"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error gcr for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_gcr: "my_gcr"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error acr for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_acr: "my_acr"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error oci for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_oci: "my_oci"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error helm for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_helm: "my_helm"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error kubernetes for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_kubernetes: "my_kubernetes"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error openshift for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_openshift: "my_openshift"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error nomad for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_nomad: "my_nomad"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error mesos for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_mesos: "my_mesos"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error marathon for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_marathon: "my_marathon"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error chronos for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_chronos: "my_chronos"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error aurora for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_aurora: "my_aurora"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error yarn for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_yarn: "my_yarn"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error hdfs for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_hdfs: "my_hdfs"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error mapreduce for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_mapreduce: "my_mapreduce"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error zookeeper for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_zookeeper: "my_zookeeper"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error bookkeeper for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_bookkeeper: "my_bookkeeper"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error pulsar for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_pulsar: "my_pulsar"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error flume for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_flume: "my_flume"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sqoop for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sqoop: "my_sqoop"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error oozie for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_oozie: "my_oozie"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ambari for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ambari: "my_ambari"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error cloudera_manager for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_cloudera_manager: "my_cloudera_manager"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error hortonworks for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_hortonworks: "my_hortonworks"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error mapr for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_mapr: "my_mapr"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error Pivotal for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_pivotal: "my_pivotal"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ibm_cloud_pak_for_data for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ibm_cloud_pak_for_data: "my_ibm_cloud_pak_for_data"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error google_dataproc for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_google_dataproc: "my_google_dataproc"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error aws_emr for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_aws_emr: "my_aws_emr"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error azure_hdinsight for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_azure_hdinsight: "my_azure_hdinsight"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error cloudera_data_platform for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_cloudera_data_platform: "my_cloudera_data_platform"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error qds for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_qds: "my_qds"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error qubole for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_qubole: "my_qubole"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error teradata_vantage for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_teradata_vantage: "my_teradata_vantage"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error yellowbrick for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_yellowbrick: "my_yellowbrick"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error actian for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_actian: "my_actian"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error exasol for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_exasol: "my_exasol"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error memsql for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_memsql: "my_memsql"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error nuodb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_nuodb: "my_nuodb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error volt_db for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_volt_db: "my_volt_db"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error cockroachdb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_cockroachdb: "my_cockroachdb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error yugabytedb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_yugabytedb: "my_yugabytedb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error tidb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_tidb: "my_tidb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error oceanbase for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_oceanbase: "my_oceanbase"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error scylladb for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_scylladb: "my_scylladb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error aerospike for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_aerospike: "my_aerospike"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error FoundationDB for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_foundationdb: "my_foundationdb"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error hazelcast for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_hazelcast: "my_hazelcast"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ignite for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ignite: "my_ignite"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error geode for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_geode: "my_geode"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error gemfire for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_gemfire: "my_gemfire"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error gridgain for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_gridgain: "my_gridgain"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error coherence for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_coherence: "my_coherence"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error infinispan for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_infinispan: "my_infinispan"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error jboss_datagrid for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_jboss_datagrid: "my_jboss_datagrid"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error pivotal_gemfire for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_pivotal_gemfire: "my_pivotal_gemfire"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error oracle_coherence for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_oracle_coherence: "my_oracle_coherence"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ibm_websphere_extreme_scale for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ibm_websphere_extreme_scale: "my_ibm_websphere_extreme_scale"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error terracotta for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_terracotta: "my_terracotta"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ehcache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ehcache: "my_ehcache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error caffeine for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_caffeine: "my_caffeine"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error guava_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_guava_cache: "my_guava_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error commons_jcs for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_commons_jcs: "my_commons_jcs"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error oscache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_oscache: "my_oscache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error jcs for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_jcs: "my_jcs"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error jcache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_jcache: "my_jcache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error spring_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_spring_cache: "my_spring_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error grails_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_grails_cache: "my_grails_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error play_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_play_cache: "my_play_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error rails_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_rails_cache: "my_rails_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error django_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_django_cache: "my_django_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error flask_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_flask_cache: "my_flask_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error pyramid_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_pyramid_cache: "my_pyramid_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error bottle_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_bottle_cache: "my_bottle_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error tornado_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_tornado_cache: "my_tornado_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error sanic_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_sanic_cache: "my_sanic_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error falcon_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_falcon_cache: "my_falcon_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error hug_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_hug_cache: "my_hug_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error apistar_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_apistar_cache: "my_apistar_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error fastapi_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_fastapi_cache: "my_fastapi_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error starlette_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_starlette_cache: "my_starlette_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error quart_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_quart_cache: "my_quart_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error aiohttp_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_aiohttp_cache: "my_aiohttp_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error vibora_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_vibora_cache: "my_vibora_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error japronto_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_japronto_cache: "my_japronto_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error uvloop_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_uvloop_cache: "my_uvloop_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error curio_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_curio_cache: "my_curio_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error trio_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_trio_cache: "my_trio_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error gevent_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_gevent_cache: "my_gevent_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error eventlet_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_eventlet_cache: "my_eventlet_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error twisted_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_twisted_cache: "my_twisted_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error asyncio_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_asyncio_cache: "my_asyncio_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error celery_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_celery_cache: "my_celery_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error rq_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_rq_cache: "my_rq_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error huey_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_huey_cache: "my_huey_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error dramatiq_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_dramatiq_cache: "my_dramatiq_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error arq_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_arq_cache: "my_arq_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error taskiq_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_taskiq_cache: "my_taskiq_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error machinery_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_machinery_cache: "my_machinery_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error zappa_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_zappa_cache: "my_zappa_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error serverless_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_serverless_cache: "my_serverless_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error aws_lambda_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_aws_lambda_cache: "my_aws_lambda_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error google_cloud_functions_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_google_cloud_functions_cache: "my_google_cloud_functions_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error azure_functions_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_azure_functions_cache: "my_azure_functions_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error openwhisk_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_openwhisk_cache: "my_openwhisk_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error knative_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_knative_cache: "my_knative_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error fn_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_fn_cache: "my_fn_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error ironfunctions_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_ironfunctions_cache: "my_ironfunctions_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error openfaas_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_openfaas_cache: "my_openfaas_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error kubeless_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_kubeless_cache: "my_kubeless_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error fission_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_fission_cache: "my_fission_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error nuclio_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_nuclio_cache: "my_nuclio_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error riff_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_riff_cache: "my_riff_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_netes_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_netes_cache: "my_faas_netes_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faasd_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faasd_cache: "my_faasd_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_cli_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_cli_cache: "my_faas_cli_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_swarm_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_swarm_cache: "my_faas_swarm_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_nomad_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_nomad_cache: "my_faas_nomad_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_mesos_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_mesos_cache: "my_faas_mesos_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_marathon_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_marathon_cache: "my_faas_marathon_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_chronos_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_chronos_cache: "my_faas_chronos_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_aurora_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_aurora_cache: "my_faas_aurora_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_yarn_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_yarn_cache: "my_faas_yarn_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_hdfs_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_hdfs_cache: "my_faas_hdfs_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_mapreduce_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_mapreduce_cache: "my_faas_mapreduce_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_zookeeper_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_zookeeper_cache: "my_faas_zookeeper_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_bookkeeper_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_bookkeeper_cache: "my_faas_bookkeeper_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_pulsar_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_pulsar_cache: "my_faas_pulsar_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_flume_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_flume_cache: "my_faas_flume_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_sqoop_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_sqoop_cache: "my_faas_sqoop_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_oozie_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_oozie_cache: "my_faas_oozie_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_ambari_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_ambari_cache: "my_faas_ambari_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_cloudera_manager_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_cloudera_manager_cache: "my_faas_cloudera_manager_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_hortonworks_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_hortonworks_cache: "my_faas_hortonworks_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_mapr_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_mapr_cache: "my_faas_mapr_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_pivotal_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_pivotal_cache: "my_faas_pivotal_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_ibm_cloud_pak_for_data_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_ibm_cloud_pak_for_data_cache: "my_faas_ibm_cloud_pak_for_data_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_google_dataproc_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_google_dataproc_cache: "my_faas_google_dataproc_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_aws_emr_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_aws_emr_cache: "my_faas_aws_emr_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_azure_hdinsight_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_azure_hdinsight_cache: "my_faas_azure_hdinsight_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_cloudera_data_platform_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_cloudera_data_platform_cache: "my_faas_cloudera_data_platform_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_qds_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_qds_cache: "my_faas_qds_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_qubole_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_qubole_cache: "my_faas_qubole_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_teradata_vantage_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_teradata_vantage_cache: "my_faas_teradata_vantage_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_yellowbrick_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_yellowbrick_cache: "my_faas_yellowbrick_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_actian_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_actian_cache: "my_faas_actian_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_exasol_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_exasol_cache: "my_faas_exasol_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_memsql_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_memsql_cache: "my_faas_memsql_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_nuodb_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_nuodb_cache: "my_faas_nuodb_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_volt_db_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_volt_db_cache: "my_faas_volt_db_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_cockroachdb_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_cockroachdb_cache: "my_faas_cockroachdb_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_yugabytedb_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_yugabytedb_cache: "my_faas_yugabytedb_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_tidb_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_tidb_cache: "my_faas_tidb_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_oceanbase_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_oceanbase_cache: "my_faas_oceanbase_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_scylladb_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_scylladb_cache: "my_faas_scylladb_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_aerospike_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_aerospike_cache: "my_faas_aerospike_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_foundationdb_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_foundationdb_cache: "my_faas_foundationdb_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_hazelcast_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_hazelcast_cache: "my_faas_hazelcast_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_ignite_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_ignite_cache: "my_faas_ignite_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_geode_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_geode_cache: "my_faas_geode_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_gemfire_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_gemfire_cache: "my_faas_gemfire_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_gridgain_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_gridgain_cache: "my_faas_gridgain_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_coherence_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_coherence_cache: "my_faas_coherence_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_infinispan_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_infinispan_cache: "my_faas_infinispan_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_jboss_datagrid_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_jboss_datagrid_cache: "my_faas_jboss_datagrid_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_pivotal_gemfire_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_pivotal_gemfire_cache: "my_faas_pivotal_gemfire_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_oracle_coherence_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_oracle_coherence_cache: "my_faas_oracle_coherence_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_ibm_websphere_extreme_scale_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_ibm_websphere_extreme_scale_cache: "my_faas_ibm_websphere_extreme_scale_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_terracotta_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_terracotta_cache: "my_faas_terracotta_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_ehcache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_ehcache_cache: "my_faas_ehcache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_caffeine_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_caffeine_cache: "my_faas_caffeine_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_guava_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_guava_cache_cache: "my_faas_guava_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_commons_jcs_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_commons_jcs_cache: "my_faas_commons_jcs_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_oscache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_oscache_cache: "my_faas_oscache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_jcs_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_jcs_cache: "my_faas_jcs_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_jcache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_jcache_cache: "my_faas_jcache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_spring_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_spring_cache_cache: "my_faas_spring_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_grails_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_grails_cache_cache: "my_faas_grails_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_play_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_play_cache_cache: "my_faas_play_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_rails_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_rails_cache_cache: "my_faas_rails_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_django_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_django_cache_cache: "my_faas_django_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_flask_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_flask_cache_cache: "my_faas_flask_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_pyramid_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_pyramid_cache_cache: "my_faas_pyramid_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_bottle_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_bottle_cache_cache: "my_faas_bottle_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_tornado_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_tornado_cache_cache: "my_faas_tornado_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_sanic_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_sanic_cache_cache: "my_faas_sanic_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_falcon_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_falcon_cache_cache: "my_faas_falcon_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_hug_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_hug_cache_cache: "my_faas_hug_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_apistar_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_apistar_cache_cache: "my_faas_apistar_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_fastapi_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_fastapi_cache_cache: "my_faas_fastapi_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_starlette_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_starlette_cache_cache: "my_faas_starlette_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_quart_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_quart_cache_cache: "my_faas_quart_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_aiohttp_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_aiohttp_cache_cache: "my_faas_aiohttp_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_vibora_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_vibora_cache_cache: "my_faas_vibora_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_japronto_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_japronto_cache_cache: "my_faas_japronto_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_uvloop_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_uvloop_cache_cache: "my_faas_uvloop_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_curio_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_curio_cache_cache: "my_faas_curio_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_trio_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_trio_cache_cache: "my_faas_trio_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_gevent_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_gevent_cache_cache: "my_faas_gevent_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_eventlet_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_eventlet_cache_cache: "my_faas_eventlet_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_twisted_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_twisted_cache_cache: "my_faas_twisted_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_asyncio_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_asyncio_cache_cache: "my_faas_asyncio_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_celery_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_celery_cache_cache: "my_faas_celery_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_rq_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_rq_cache_cache: "my_faas_rq_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_huey_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_huey_cache_cache: "my_faas_huey_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_dramatiq_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_dramatiq_cache_cache: "my_faas_dramatiq_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_arq_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_arq_cache_cache: "my_faas_arq_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_taskiq_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_taskiq_cache_cache: "my_faas_taskiq_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_machinery_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_machinery_cache_cache: "my_faas_machinery_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_zappa_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_zappa_cache_cache: "my_faas_zappa_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_serverless_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_serverless_cache_cache: "my_faas_serverless_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_aws_lambda_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_aws_lambda_cache_cache: "my_faas_aws_lambda_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_google_cloud_functions_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_google_cloud_functions_cache_cache: "my_faas_google_cloud_functions_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_azure_functions_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_azure_functions_cache_cache: "my_faas_azure_functions_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_openwhisk_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_openwhisk_cache_cache: "my_faas_openwhisk_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_knative_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_knative_cache_cache: "my_faas_knative_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_fn_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_fn_cache_cache: "my_faas_fn_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_ironfunctions_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_ironfunctions_cache_cache: "my_faas_ironfunctions_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_openfaas_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_openfaas_cache_cache: "my_faas_openfaas_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_kubeless_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_kubeless_cache_cache: "my_faas_kubeless_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_fission_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_fission_cache_cache: "my_faas_fission_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_nuclio_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_nuclio_cache_cache: "my_faas_nuclio_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_riff_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_riff_cache_cache: "my_faas_riff_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_netes_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_netes_cache_cache: "my_faas_faas_netes_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faasd_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faasd_cache_cache: "my_faas_faasd_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_cli_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_cli_cache_cache: "my_faas_faas_cli_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_swarm_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_swarm_cache_cache: "my_faas_faas_swarm_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_nomad_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_nomad_cache_cache: "my_faas_faas_nomad_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_mesos_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_mesos_cache_cache: "my_faas_faas_mesos_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_marathon_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_marathon_cache_cache: "my_faas_faas_marathon_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_chronos_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_chronos_cache_cache: "my_faas_faas_chronos_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_aurora_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_aurora_cache_cache: "my_faas_faas_aurora_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_yarn_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_yarn_cache_cache: "my_faas_faas_yarn_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_hdfs_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_hdfs_cache_cache: "my_faas_faas_hdfs_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_mapreduce_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_mapreduce_cache_cache: "my_faas_faas_mapreduce_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_zookeeper_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_zookeeper_cache_cache: "my_faas_faas_zookeeper_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_bookkeeper_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_bookkeeper_cache_cache: "my_faas_faas_bookkeeper_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_pulsar_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_pulsar_cache_cache: "my_faas_faas_pulsar_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_flume_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_flume_cache_cache: "my_faas_faas_flume_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_sqoop_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_sqoop_cache_cache: "my_faas_faas_sqoop_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_oozie_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_oozie_cache_cache: "my_faas_faas_oozie_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_ambari_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_ambari_cache_cache: "my_faas_faas_ambari_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_cloudera_manager_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_cloudera_manager_cache_cache: "my_faas_faas_cloudera_manager_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_hortonworks_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_hortonworks_cache_cache: "my_faas_faas_hortonworks_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_mapr_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_mapr_cache_cache: "my_faas_faas_mapr_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_pivotal_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_pivotal_cache_cache: "my_faas_faas_pivotal_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_ibm_cloud_pak_for_data_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_ibm_cloud_pak_for_data_cache_cache: "my_faas_faas_ibm_cloud_pak_for_data_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_google_dataproc_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_google_dataproc_cache_cache: "my_faas_faas_google_dataproc_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_aws_emr_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_aws_emr_cache_cache: "my_faas_faas_aws_emr_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_azure_hdinsight_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_azure_hdinsight_cache_cache: "my_faas_faas_azure_hdinsight_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_cloudera_data_platform_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_cloudera_data_platform_cache_cache: "my_faas_faas_cloudera_data_platform_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_qds_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_qds_cache_cache: "my_faas_faas_qds_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_qubole_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_qubole_cache_cache: "my_faas_faas_qubole_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_teradata_vantage_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_teradata_vantage_cache_cache: "my_faas_faas_teradata_vantage_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_yellowbrick_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_yellowbrick_cache_cache: "my_faas_faas_yellowbrick_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_actian_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_actian_cache_cache: "my_faas_faas_actian_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_exasol_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_exasol_cache_cache: "my_faas_faas_exasol_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_memsql_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_memsql_cache_cache: "my_faas_faas_memsql_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_nuodb_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_nuodb_cache_cache: "my_faas_faas_nuodb_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_volt_db_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_volt_db_cache_cache: "my_faas_faas_volt_db_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_cockroachdb_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_cockroachdb_cache_cache: "my_faas_faas_cockroachdb_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_yugabytedb_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_yugabytedb_cache_cache: "my_faas_faas_yugabytedb_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_tidb_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_tidb_cache_cache: "my_faas_faas_tidb_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_oceanbase_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_oceanbase_cache_cache: "my_faas_faas_oceanbase_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_scylladb_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_scylladb_cache_cache: "my_faas_faas_scylladb_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_aerospike_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_aerospike_cache_cache: "my_faas_faas_aerospike_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_foundationdb_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_foundationdb_cache_cache: "my_faas_faas_foundationdb_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_hazelcast_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_hazelcast_cache_cache: "my_faas_faas_hazelcast_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_ignite_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_ignite_cache_cache: "my_faas_faas_ignite_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_geode_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_geode_cache_cache: "my_faas_faas_geode_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_gemfire_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_gemfire_cache_cache: "my_faas_faas_gemfire_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_gridgain_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_gridgain_cache_cache: "my_faas_faas_gridgain_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_coherence_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_coherence_cache_cache: "my_faas_faas_coherence_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_infinispan_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_infinispan_cache_cache: "my_faas_faas_infinispan_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_jboss_datagrid_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_jboss_datagrid_cache_cache: "my_faas_faas_jboss_datagrid_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_pivotal_gemfire_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_pivotal_gemfire_cache_cache: "my_faas_faas_pivotal_gemfire_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_oracle_coherence_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_oracle_coherence_cache_cache: "my_faas_faas_oracle_coherence_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_ibm_websphere_extreme_scale_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_ibm_websphere_extreme_scale_cache_cache: "my_faas_faas_ibm_websphere_extreme_scale_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_terracotta_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_terracotta_cache_cache: "my_faas_faas_terracotta_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_ehcache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_ehcache_cache_cache: "my_faas_faas_ehcache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_caffeine_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_caffeine_cache_cache: "my_faas_faas_caffeine_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_guava_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_guava_cache_cache_cache: "my_faas_faas_guava_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_commons_jcs_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_commons_jcs_cache_cache: "my_faas_faas_commons_jcs_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_oscache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_oscache_cache_cache: "my_faas_faas_oscache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_jcs_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_jcs_cache_cache: "my_faas_faas_jcs_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_jcache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_jcache_cache_cache: "my_faas_faas_jcache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_spring_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_spring_cache_cache_cache: "my_faas_faas_spring_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_grails_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_grails_cache_cache_cache: "my_faas_faas_grails_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_play_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_play_cache_cache_cache: "my_faas_faas_play_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_rails_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_rails_cache_cache_cache: "my_faas_faas_rails_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_django_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_django_cache_cache_cache: "my_faas_faas_django_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_flask_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_flask_cache_cache_cache: "my_faas_faas_flask_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_pyramid_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_pyramid_cache_cache_cache: "my_faas_faas_pyramid_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_bottle_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_bottle_cache_cache_cache: "my_faas_faas_bottle_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_tornado_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_tornado_cache_cache_cache: "my_faas_faas_tornado_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_sanic_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_sanic_cache_cache_cache: "my_faas_faas_sanic_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_falcon_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_falcon_cache_cache_cache: "my_faas_faas_falcon_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_hug_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_hug_cache_cache_cache: "my_faas_faas_hug_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_apistar_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_apistar_cache_cache_cache: "my_faas_faas_apistar_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_fastapi_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_fastapi_cache_cache_cache: "my_faas_faas_fastapi_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_starlette_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_starlette_cache_cache_cache: "my_faas_faas_starlette_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_quart_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_quart_cache_cache_cache: "my_faas_faas_quart_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_aiohttp_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_aiohttp_cache_cache_cache: "my_faas_faas_aiohttp_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_vibora_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_vibora_cache_cache_cache: "my_faas_faas_vibora_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_japronto_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_japronto_cache_cache_cache: "my_faas_faas_japronto_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_uvloop_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_uvloop_cache_cache_cache: "my_faas_faas_uvloop_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_curio_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_curio_cache_cache_cache: "my_faas_faas_curio_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_trio_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_trio_cache_cache_cache: "my_faas_faas_trio_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_gevent_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_gevent_cache_cache_cache: "my_faas_faas_gevent_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_eventlet_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_eventlet_cache_cache_cache: "my_faas_faas_eventlet_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_twisted_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_twisted_cache_cache_cache: "my_faas_faas_twisted_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_asyncio_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_asyncio_cache_cache_cache: "my_faas_faas_asyncio_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_celery_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_celery_cache_cache_cache: "my_faas_faas_celery_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_rq_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_rq_cache_cache_cache: "my_faas_faas_rq_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_huey_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_huey_cache_cache_cache: "my_faas_faas_huey_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_dramatiq_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_dramatiq_cache_cache_cache: "my_faas_faas_dramatiq_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_arq_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_arq_cache_cache_cache: "my_faas_faas_arq_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_taskiq_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_taskiq_cache_cache_cache: "my_faas_faas_taskiq_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_machinery_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_machinery_cache_cache_cache: "my_faas_faas_machinery_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_zappa_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_zappa_cache_cache_cache: "my_faas_faas_zappa_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_serverless_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_serverless_cache_cache_cache: "my_faas_faas_serverless_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_aws_lambda_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_aws_lambda_cache_cache_cache: "my_faas_faas_aws_lambda_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_google_cloud_functions_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_google_cloud_functions_cache_cache_cache: "my_faas_faas_google_cloud_functions_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_azure_functions_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_azure_functions_cache_cache_cache: "my_faas_faas_azure_functions_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_openwhisk_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_openwhisk_cache_cache_cache: "my_faas_faas_openwhisk_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_knative_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_knative_cache_cache_cache: "my_faas_faas_knative_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_fn_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_fn_cache_cache_cache: "my_faas_faas_fn_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_ironfunctions_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_ironfunctions_cache_cache_cache: "my_faas_faas_ironfunctions_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_openfaas_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_openfaas_cache_cache_cache: "my_faas_faas_openfaas_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_kubeless_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_kubeless_cache_cache_cache: "my_faas_faas_kubeless_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_fission_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_fission_cache_cache_cache: "my_faas_faas_fission_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_nuclio_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_nuclio_cache_cache_cache: "my_faas_faas_nuclio_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_riff_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_riff_cache_cache_cache: "my_faas_faas_riff_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_netes_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_netes_cache_cache_cache: "my_faas_faas_faas_netes_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faasd_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faasd_cache_cache_cache: "my_faas_faas_faasd_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_cli_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_cli_cache_cache_cache: "my_faas_faas_faas_cli_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_swarm_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_swarm_cache_cache_cache: "my_faas_faas_faas_swarm_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_nomad_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_nomad_cache_cache_cache: "my_faas_faas_faas_nomad_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_mesos_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_mesos_cache_cache_cache: "my_faas_faas_faas_mesos_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_marathon_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_marathon_cache_cache_cache: "my_faas_faas_faas_marathon_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_chronos_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_chronos_cache_cache_cache: "my_faas_faas_faas_chronos_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_aurora_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_aurora_cache_cache_cache: "my_faas_faas_faas_aurora_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_yarn_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_yarn_cache_cache_cache: "my_faas_faas_faas_yarn_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_hdfs_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_hdfs_cache_cache_cache: "my_faas_faas_faas_hdfs_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_mapreduce_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_mapreduce_cache_cache_cache: "my_faas_faas_faas_mapreduce_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_zookeeper_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_zookeeper_cache_cache_cache: "my_faas_faas_faas_zookeeper_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_bookkeeper_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_bookkeeper_cache_cache_cache: "my_faas_faas_faas_bookkeeper_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_pulsar_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_pulsar_cache_cache_cache: "my_faas_faas_faas_pulsar_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_flume_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_flume_cache_cache_cache: "my_faas_faas_faas_flume_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_sqoop_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_sqoop_cache_cache_cache: "my_faas_faas_faas_sqoop_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_oozie_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_oozie_cache_cache_cache: "my_faas_faas_faas_oozie_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_ambari_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_ambari_cache_cache_cache: "my_faas_faas_faas_ambari_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_cloudera_manager_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_cloudera_manager_cache_cache_cache: "my_faas_faas_faas_cloudera_manager_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_hortonworks_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_hortonworks_cache_cache_cache: "my_faas_faas_faas_hortonworks_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_mapr_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_mapr_cache_cache_cache: "my_faas_faas_faas_mapr_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_pivotal_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_pivotal_cache_cache_cache: "my_faas_faas_faas_pivotal_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_ibm_cloud_pak_for_data_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_ibm_cloud_pak_for_data_cache_cache_cache: "my_faas_faas_faas_ibm_cloud_pak_for_data_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_google_dataproc_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_google_dataproc_cache_cache_cache: "my_faas_faas_faas_google_dataproc_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_aws_emr_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_aws_emr_cache_cache_cache: "my_faas_faas_faas_aws_emr_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_azure_hdinsight_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_azure_hdinsight_cache_cache_cache: "my_faas_faas_faas_azure_hdinsight_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_cloudera_data_platform_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_cloudera_data_platform_cache_cache_cache: "my_faas_faas_faas_cloudera_data_platform_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_qds_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_qds_cache_cache_cache: "my_faas_faas_faas_qds_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_qubole_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_qubole_cache_cache_cache: "my_faas_faas_faas_qubole_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_teradata_vantage_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_teradata_vantage_cache_cache_cache: "my_faas_faas_faas_teradata_vantage_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_yellowbrick_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_yellowbrick_cache_cache_cache: "my_faas_faas_faas_yellowbrick_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_actian_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_actian_cache_cache_cache: "my_faas_faas_faas_actian_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_exasol_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_exasol_cache_cache_cache: "my_faas_faas_faas_exasol_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_memsql_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_memsql_cache_cache_cache: "my_faas_faas_faas_memsql_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_nuodb_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_nuodb_cache_cache_cache: "my_faas_faas_faas_nuodb_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_volt_db_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_volt_db_cache_cache_cache: "my_faas_faas_faas_volt_db_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_cockroachdb_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_cockroachdb_cache_cache_cache: "my_faas_faas_faas_cockroachdb_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_yugabytedb_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_yugabytedb_cache_cache_cache: "my_faas_faas_faas_yugabytedb_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_tidb_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_tidb_cache_cache_cache: "my_faas_faas_faas_tidb_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_oceanbase_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_oceanbase_cache_cache_cache: "my_faas_faas_faas_oceanbase_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_scylladb_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_scylladb_cache_cache_cache: "my_faas_faas_faas_scylladb_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_aerospike_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_aerospike_cache_cache_cache: "my_faas_faas_faas_aerospike_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_foundationdb_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_foundationdb_cache_cache_cache: "my_faas_faas_faas_foundationdb_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_hazelcast_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_hazelcast_cache_cache_cache: "my_faas_faas_faas_hazelcast_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_ignite_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_ignite_cache_cache_cache: "my_faas_faas_faas_ignite_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_geode_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_geode_cache_cache_cache: "my_faas_faas_faas_geode_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_gemfire_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_gemfire_cache_cache_cache: "my_faas_faas_faas_gemfire_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_gridgain_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_gridgain_cache_cache_cache: "my_faas_faas_faas_gridgain_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_coherence_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_coherence_cache_cache_cache: "my_faas_faas_faas_coherence_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_infinispan_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_infinispan_cache_cache_cache: "my_faas_faas_faas_infinispan_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_jboss_datagrid_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_jboss_datagrid_cache_cache_cache: "my_faas_faas_faas_jboss_datagrid_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_pivotal_gemfire_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_pivotal_gemfire_cache_cache_cache: "my_faas_faas_faas_pivotal_gemfire_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_oracle_coherence_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_oracle_coherence_cache_cache_cache: "my_faas_faas_faas_oracle_coherence_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_ibm_websphere_extreme_scale_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_ibm_websphere_extreme_scale_cache_cache_cache: "my_faas_faas_faas_ibm_websphere_extreme_scale_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_terracotta_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_terracotta_cache_cache_cache: "my_faas_faas_faas_terracotta_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_ehcache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_ehcache_cache_cache_cache: "my_faas_faas_faas_ehcache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_caffeine_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_caffeine_cache_cache_cache: "my_faas_faas_faas_caffeine_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_guava_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_guava_cache_cache_cache_cache: "my_faas_faas_faas_guava_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_commons_jcs_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_commons_jcs_cache_cache_cache: "my_faas_faas_faas_commons_jcs_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_oscache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_oscache_cache_cache_cache: "my_faas_faas_faas_oscache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_jcs_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_jcs_cache_cache_cache: "my_faas_faas_faas_jcs_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_jcache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_jcache_cache_cache_cache: "my_faas_faas_faas_jcache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_spring_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_spring_cache_cache_cache_cache: "my_faas_faas_faas_spring_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_grails_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_grails_cache_cache_cache_cache: "my_faas_faas_faas_grails_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_play_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_play_cache_cache_cache_cache: "my_faas_faas_faas_play_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_rails_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_rails_cache_cache_cache_cache: "my_faas_faas_faas_rails_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_django_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_django_cache_cache_cache_cache: "my_faas_faas_faas_django_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_flask_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_flask_cache_cache_cache_cache: "my_faas_faas_faas_flask_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_pyramid_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_pyramid_cache_cache_cache_cache: "my_faas_faas_faas_pyramid_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_bottle_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_bottle_cache_cache_cache_cache: "my_faas_faas_faas_bottle_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_tornado_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_tornado_cache_cache_cache_cache: "my_faas_faas_faas_tornado_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_sanic_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_sanic_cache_cache_cache_cache: "my_faas_faas_faas_sanic_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_falcon_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_falcon_cache_cache_cache_cache: "my_faas_faas_faas_falcon_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_hug_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_hug_cache_cache_cache_cache: "my_faas_faas_faas_hug_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_apistar_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_apistar_cache_cache_cache_cache: "my_faas_faas_faas_apistar_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_fastapi_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_fastapi_cache_cache_cache_cache: "my_faas_faas_faas_fastapi_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_starlette_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_starlette_cache_cache_cache_cache: "my_faas_faas_faas_starlette_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_quart_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_quart_cache_cache_cache_cache: "my_faas_faas_faas_quart_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_aiohttp_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_aiohttp_cache_cache_cache_cache: "my_faas_faas_faas_aiohttp_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_vibora_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_vibora_cache_cache_cache_cache: "my_faas_faas_faas_vibora_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_japronto_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_japronto_cache_cache_cache_cache: "my_faas_faas_faas_japronto_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_uvloop_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_uvloop_cache_cache_cache_cache: "my_faas_faas_faas_uvloop_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_curio_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_curio_cache_cache_cache_cache: "my_faas_faas_faas_curio_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_trio_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_trio_cache_cache_cache_cache: "my_faas_faas_faas_trio_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_gevent_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_gevent_cache_cache_cache_cache: "my_faas_faas_faas_gevent_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_eventlet_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_eventlet_cache_cache_cache_cache: "my_faas_faas_faas_eventlet_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_twisted_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_twisted_cache_cache_cache_cache: "my_faas_faas_faas_twisted_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_asyncio_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_asyncio_cache_cache_cache_cache: "my_faas_faas_faas_asyncio_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_celery_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_celery_cache_cache_cache_cache: "my_faas_faas_faas_celery_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_rq_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_rq_cache_cache_cache_cache: "my_faas_faas_faas_rq_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_huey_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_huey_cache_cache_cache_cache: "my_faas_faas_faas_huey_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_dramatiq_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_dramatiq_cache_cache_cache_cache: "my_faas_faas_faas_dramatiq_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_arq_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_arq_cache_cache_cache_cache: "my_faas_faas_faas_arq_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_taskiq_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_taskiq_cache_cache_cache_cache: "my_faas_faas_faas_taskiq_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_machinery_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_machinery_cache_cache_cache_cache: "my_faas_faas_faas_machinery_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_zappa_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_zappa_cache_cache_cache_cache: "my_faas_faas_faas_zappa_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_serverless_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_serverless_cache_cache_cache_cache: "my_faas_faas_faas_serverless_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_aws_lambda_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_aws_lambda_cache_cache_cache_cache: "my_faas_faas_faas_aws_lambda_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_google_cloud_functions_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_google_cloud_functions_cache_cache_cache_cache: "my_faas_faas_faas_google_cloud_functions_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_azure_functions_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_azure_functions_cache_cache_cache_cache: "my_faas_faas_faas_azure_functions_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_openwhisk_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_openwhisk_cache_cache_cache_cache: "my_faas_faas_faas_openwhisk_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_knative_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_knative_cache_cache_cache_cache: "my_faas_faas_faas_knative_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_fn_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_fn_cache_cache_cache_cache: "my_faas_faas_faas_fn_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_ironfunctions_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_ironfunctions_cache_cache_cache_cache: "my_faas_faas_faas_ironfunctions_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_openfaas_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_openfaas_cache_cache_cache_cache: "my_faas_faas_faas_openfaas_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_kubeless_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_kubeless_cache_cache_cache_cache: "my_faas_faas_faas_kubeless_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_fission_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_fission_cache_cache_cache_cache: "my_faas_faas_faas_fission_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_nuclio_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_nuclio_cache_cache_cache_cache: "my_faas_faas_faas_nuclio_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_riff_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_riff_cache_cache_cache_cache: "my_faas_faas_faas_riff_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_netes_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_netes_cache_cache_cache_cache: "my_faas_faas_faas_faas_netes_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faasd_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faasd_cache_cache_cache_cache: "my_faas_faas_faas_faasd_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_cli_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_cli_cache_cache_cache_cache: "my_faas_faas_faas_faas_cli_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_swarm_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_swarm_cache_cache_cache_cache: "my_faas_faas_faas_faas_swarm_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_nomad_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_nomad_cache_cache_cache_cache: "my_faas_faas_faas_faas_nomad_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_mesos_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_mesos_cache_cache_cache_cache: "my_faas_faas_faas_faas_mesos_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_marathon_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_marathon_cache_cache_cache_cache: "my_faas_faas_faas_faas_marathon_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_chronos_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_chronos_cache_cache_cache_cache: "my_faas_faas_faas_faas_chronos_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_aurora_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_aurora_cache_cache_cache_cache: "my_faas_faas_faas_faas_aurora_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_yarn_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_yarn_cache_cache_cache_cache: "my_faas_faas_faas_faas_yarn_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_hdfs_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_hdfs_cache_cache_cache_cache: "my_faas_faas_faas_faas_hdfs_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_mapreduce_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_mapreduce_cache_cache_cache_cache: "my_faas_faas_faas_faas_mapreduce_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_zookeeper_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_zookeeper_cache_cache_cache_cache: "my_faas_faas_faas_faas_zookeeper_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_bookkeeper_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_bookkeeper_cache_cache_cache_cache: "my_faas_faas_faas_faas_bookkeeper_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_pulsar_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_pulsar_cache_cache_cache_cache: "my_faas_faas_faas_faas_pulsar_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_flume_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_flume_cache_cache_cache_cache: "my_faas_faas_faas_faas_flume_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_sqoop_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_sqoop_cache_cache_cache_cache: "my_faas_faas_faas_faas_sqoop_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_oozie_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_oozie_cache_cache_cache_cache: "my_faas_faas_faas_faas_oozie_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_ambari_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_ambari_cache_cache_cache_cache: "my_faas_faas_faas_faas_ambari_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_cloudera_manager_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_cloudera_manager_cache_cache_cache_cache: "my_faas_faas_faas_faas_cloudera_manager_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_hortonworks_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_hortonworks_cache_cache_cache_cache: "my_faas_faas_faas_faas_hortonworks_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_mapr_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_mapr_cache_cache_cache_cache: "my_faas_faas_faas_faas_mapr_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_pivotal_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_pivotal_cache_cache_cache_cache: "my_faas_faas_faas_faas_pivotal_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_ibm_cloud_pak_for_data_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_ibm_cloud_pak_for_data_cache_cache_cache_cache: "my_faas_faas_faas_faas_ibm_cloud_pak_for_data_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_google_dataproc_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_google_dataproc_cache_cache_cache_cache: "my_faas_faas_faas_faas_google_dataproc_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_aws_emr_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_aws_emr_cache_cache_cache_cache: "my_faas_faas_faas_faas_aws_emr_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_azure_hdinsight_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_azure_hdinsight_cache_cache_cache_cache: "my_faas_faas_faas_faas_azure_hdinsight_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_cloudera_data_platform_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_cloudera_data_platform_cache_cache_cache_cache: "my_faas_faas_faas_faas_cloudera_data_platform_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_qds_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_qds_cache_cache_cache_cache: "my_faas_faas_faas_faas_qds_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_qubole_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_qubole_cache_cache_cache_cache: "my_faas_faas_faas_faas_qubole_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_teradata_vantage_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_teradata_vantage_cache_cache_cache_cache: "my_faas_faas_faas_faas_teradata_vantage_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_yellowbrick_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_yellowbrick_cache_cache_cache_cache: "my_faas_faas_faas_faas_yellowbrick_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_actian_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_actian_cache_cache_cache_cache: "my_faas_faas_faas_faas_actian_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_exasol_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_exasol_cache_cache_cache_cache: "my_faas_faas_faas_faas_exasol_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_memsql_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_memsql_cache_cache_cache_cache: "my_faas_faas_faas_faas_memsql_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_nuodb_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_nuodb_cache_cache_cache_cache: "my_faas_faas_faas_faas_nuodb_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_volt_db_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_volt_db_cache_cache_cache_cache: "my_faas_faas_faas_faas_volt_db_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_cockroachdb_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_cockroachdb_cache_cache_cache_cache: "my_faas_faas_faas_faas_cockroachdb_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_yugabytedb_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_yugabytedb_cache_cache_cache_cache: "my_faas_faas_faas_faas_yugabytedb_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_tidb_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_tidb_cache_cache_cache_cache: "my_faas_faas_faas_faas_tidb_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_oceanbase_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_oceanbase_cache_cache_cache_cache: "my_faas_faas_faas_faas_oceanbase_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_scylladb_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_scylladb_cache_cache_cache_cache: "my_faas_faas_faas_faas_scylladb_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_aerospike_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_aerospike_cache_cache_cache_cache: "my_faas_faas_faas_faas_aerospike_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_foundationdb_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_foundationdb_cache_cache_cache_cache: "my_faas_faas_faas_faas_foundationdb_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_hazelcast_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_hazelcast_cache_cache_cache_cache: "my_faas_faas_faas_faas_hazelcast_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_ignite_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_ignite_cache_cache_cache_cache: "my_faas_faas_faas_faas_ignite_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_geode_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_geode_cache_cache_cache_cache: "my_faas_faas_faas_faas_geode_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_gemfire_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_gemfire_cache_cache_cache_cache: "my_faas_faas_faas_faas_gemfire_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_gridgain_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_gridgain_cache_cache_cache_cache: "my_faas_faas_faas_faas_gridgain_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_coherence_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_coherence_cache_cache_cache_cache: "my_faas_faas_faas_faas_coherence_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_infinispan_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_infinispan_cache_cache_cache_cache: "my_faas_faas_faas_faas_infinispan_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_jboss_datagrid_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_jboss_datagrid_cache_cache_cache_cache: "my_faas_faas_faas_faas_jboss_datagrid_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_pivotal_gemfire_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_pivotal_gemfire_cache_cache_cache_cache: "my_faas_faas_faas_faas_pivotal_gemfire_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_oracle_coherence_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_oracle_coherence_cache_cache_cache_cache: "my_faas_faas_faas_faas_oracle_coherence_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_ibm_websphere_extreme_scale_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_ibm_websphere_extreme_scale_cache_cache_cache_cache: "my_faas_faas_faas_faas_ibm_websphere_extreme_scale_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_terracotta_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_terracotta_cache_cache_cache_cache: "my_faas_faas_faas_faas_terracotta_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_ehcache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_ehcache_cache_cache_cache_cache: "my_faas_faas_faas_faas_ehcache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_caffeine_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_caffeine_cache_cache_cache_cache: "my_faas_faas_faas_faas_caffeine_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_guava_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_guava_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_guava_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_commons_jcs_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_commons_jcs_cache_cache_cache_cache: "my_faas_faas_faas_faas_commons_jcs_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_oscache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_oscache_cache_cache_cache_cache: "my_faas_faas_faas_faas_oscache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_jcs_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_jcs_cache_cache_cache_cache: "my_faas_faas_faas_faas_jcs_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_jcache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_jcache_cache_cache_cache_cache: "my_faas_faas_faas_faas_jcache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_spring_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_spring_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_spring_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_grails_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_grails_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_grails_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_play_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_play_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_play_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_rails_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_rails_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_rails_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_django_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_django_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_django_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_flask_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_flask_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_flask_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_pyramid_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_pyramid_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_pyramid_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_bottle_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_bottle_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_bottle_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_tornado_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_tornado_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_tornado_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_sanic_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_sanic_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_sanic_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_falcon_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_falcon_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_falcon_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_hug_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_hug_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_hug_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_apistar_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_apistar_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_apistar_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_fastapi_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_fastapi_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_fastapi_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_starlette_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_starlette_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_starlette_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_quart_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_quart_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_quart_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_aiohttp_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_aiohttp_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_aiohttp_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_vibora_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_vibora_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_vibora_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_japronto_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_japronto_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_japronto_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_uvloop_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_uvloop_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_uvloop_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_curio_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_curio_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_curio_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_trio_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_trio_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_trio_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_gevent_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_gevent_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_gevent_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_eventlet_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_eventlet_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_eventlet_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_twisted_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_twisted_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_twisted_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_asyncio_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_asyncio_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_asyncio_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_celery_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_celery_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_celery_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_rq_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_rq_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_rq_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_huey_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_huey_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_huey_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_dramatiq_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_dramatiq_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_dramatiq_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_arq_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_arq_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_arq_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_taskiq_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_taskiq_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_taskiq_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_machinery_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_machinery_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_machinery_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_zappa_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_zappa_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_zappa_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_serverless_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_serverless_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_serverless_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_aws_lambda_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_aws_lambda_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_aws_lambda_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_google_cloud_functions_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_google_cloud_functions_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_google_cloud_functions_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_azure_functions_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_azure_functions_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_azure_functions_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_openwhisk_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_openwhisk_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_openwhisk_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_knative_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_knative_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_knative_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_fn_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_fn_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_fn_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_ironfunctions_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_ironfunctions_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_ironfunctions_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_openfaas_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_openfaas_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_openfaas_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_kubeless_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_kubeless_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_kubeless_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_fission_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_fission_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_fission_cache_cache_cache_cache_cache"
+# #   # Optional: Set a custom cache invalidation prefetch backoff retryable error faas_faas_faas_faas_nuclio_cache_cache_cache_cache_cache for responses
+# #   # cache_invalidation_prefetch_backoff_retryable_error_faas_faas_faas_faas_nuclio_cache_cache_cache_cache_cache: "my_faas_faas_faas_faas_nuclio_cache_cache_cache_cache_cache"
+# #

--- a/start_services.py
+++ b/start_services.py
@@ -61,13 +61,19 @@ def start_supabase():
         "docker", "compose", "-p", "localai", "-f", "supabase/docker/docker-compose.yml", "up", "-d"
     ])
 
-def start_local_ai(profile=None):
+def start_local_ai(profile=None, services_to_start=None):
     """Start the local AI services (using its compose file)."""
-    print("Starting local AI services...")
     cmd = ["docker", "compose", "-p", "localai"]
     if profile and profile != "none":
         cmd.extend(["--profile", profile])
     cmd.extend(["-f", "docker-compose.yml", "up", "-d"])
+
+    if services_to_start:
+        print(f"Starting selected local AI services: {', '.join(services_to_start)}")
+        cmd.extend(services_to_start)
+    else:
+        print("Starting all local AI services based on profile (or no specific services requested)...")
+
     run_command(cmd)
 
 def generate_searxng_secret_key():
@@ -214,7 +220,36 @@ def main():
     parser = argparse.ArgumentParser(description='Start the local AI and Supabase services.')
     parser.add_argument('--profile', choices=['cpu', 'gpu-nvidia', 'gpu-amd', 'none'], default='cpu',
                       help='Profile to use for Docker Compose (default: cpu)')
+    parser.add_argument('--services', type=str, default=None,
+                      help='Comma-separated list of services to start (e.g., flowise,ollama,open-webui). If not provided, all services are started.')
     args = parser.parse_args()
+
+    # --- Service Definitions and Dependencies ---
+    # This map defines user-friendly names to actual service names in docker-compose
+    # and their direct dependencies.
+    SERVICE_MAP = {
+        "flowise": {"services": ["flowise"], "depends_on": []},
+        "open-webui": {"services": ["open-webui"], "depends_on": ["ollama"]},
+        "n8n": {"services": ["n8n", "n8n-import"], "depends_on": ["postgres"]},
+        "qdrant": {"services": ["qdrant"], "depends_on": []},
+        "neo4j": {"services": ["neo4j"], "depends_on": []},
+        "caddy": {"services": ["caddy"], "depends_on": []},
+        "langfuse": {
+            "services": ["langfuse-worker", "langfuse-web", "clickhouse", "minio", "postgres", "redis"],
+            "depends_on": [] # Internal dependencies are in docker-compose.yml
+        },
+        "minio": {"services": ["minio"], "depends_on": []},
+        "postgres": {"services": ["postgres"], "depends_on": []},
+        "redis": {"services": ["redis"], "depends_on": []},
+        "searxng": {"services": ["searxng"], "depends_on": []},
+        "litellm": {"services": ["litellm"], "depends_on": ["ollama", "redis"]},
+        "ollama": { # Ollama is profile-dependent
+            "cpu": {"services": ["ollama-cpu", "ollama-pull-llama-cpu"], "depends_on": []},
+            "gpu-nvidia": {"services": ["ollama-gpu", "ollama-pull-llama-gpu"], "depends_on": []},
+            "gpu-amd": {"services": ["ollama-gpu-amd", "ollama-pull-llama-gpu-amd"], "depends_on": []},
+            "none": {"services": [], "depends_on": []}
+        },
+    }
 
     clone_supabase_repo()
     prepare_supabase_env()
@@ -223,7 +258,7 @@ def main():
     generate_searxng_secret_key()
     check_and_fix_docker_compose_for_searxng()
     
-    stop_existing_containers(args.profile)
+    stop_existing_containers(args.profile) # Stops all services in the 'localai' project
     
     # Start Supabase first
     start_supabase()
@@ -232,8 +267,78 @@ def main():
     print("Waiting for Supabase to initialize...")
     time.sleep(10)
     
-    # Then start the local AI services
-    start_local_ai(args.profile)
+    # Determine which local AI services to start
+    services_to_actually_run = []
+    if args.services:
+        requested_services_input = [s.strip().lower() for s in args.services.split(',')]
+
+        services_to_process_queue = list(requested_services_input) # Queue to manage services and their dependencies
+        final_service_set = set() # Using a set to avoid duplicates
+
+        processed_for_dependencies = set() # Keep track of services whose dependencies have been added
+
+        while services_to_process_queue:
+            service_name = services_to_process_queue.pop(0)
+
+            if service_name in processed_for_dependencies:
+                continue
+
+            actual_service_names_to_add = []
+            dependencies_to_add_to_queue = []
+
+            if service_name == "ollama":
+                # Determine correct Ollama services based on profile
+                ollama_profile_key = args.profile if args.profile in SERVICE_MAP["ollama"] else "cpu"
+                if ollama_profile_key == "none": # if profile is none, ollama effectively means no services
+                    print("Ollama selected but profile is 'none'. No Ollama services will be started.")
+                    actual_service_names_to_add = []
+                else:
+                    actual_service_names_to_add = SERVICE_MAP["ollama"][ollama_profile_key]["services"]
+                # Ollama's internal services (e.g., puller) are part of its definition, no further deps here.
+            elif service_name in SERVICE_MAP:
+                service_info = SERVICE_MAP[service_name]
+                actual_service_names_to_add = service_info["services"]
+                dependencies_to_add_to_queue = service_info["depends_on"]
+            else:
+                print(f"Warning: Service '{service_name}' not recognized and will be ignored.")
+                processed_for_dependencies.add(service_name) # Mark as processed to avoid re-warning
+                continue
+
+            for s_name in actual_service_names_to_add:
+                final_service_set.add(s_name)
+
+            processed_for_dependencies.add(service_name)
+
+            for dep in dependencies_to_add_to_queue:
+                if dep not in processed_for_dependencies:
+                    services_to_process_queue.append(dep) # Add dependency to the queue
+
+        services_to_actually_run = list(final_service_set)
+
+        # Caddy is a special case: if any service is targeted for startup, Caddy should also run.
+        if services_to_actually_run and "caddy" not in services_to_actually_run and "caddy" in SERVICE_MAP:
+            caddy_services = SERVICE_MAP["caddy"]["services"]
+            if not any(cs in services_to_actually_run for cs in caddy_services): # Avoid adding if already present
+                 print("Adding 'caddy' service as other services are being started.")
+                 services_to_actually_run.extend(caddy_services)
+
+
+        if not services_to_actually_run and requested_services_input:
+            # This means user specified services, but none were valid or resolved to actual service names
+            print("No valid services were selected to start. Supabase is running. No other Local AI services will be started.")
+            sys.exit(0) # Exit gracefully, Supabase is up, but no local AI services.
+
+    if args.services is None:
+        # No specific services requested, start all services for the given profile
+        print("No specific services selected via --services, starting all Local AI services for the profile.")
+        start_local_ai(args.profile)
+    elif services_to_actually_run:
+        # Start the selected and dependency-resolved services
+        start_local_ai(args.profile, services_to_actually_run)
+    else:
+        # This case implies args.services was given, but resulted in an empty list (e.g. only "ollama" with profile "none")
+        # and no other services that would pull in Caddy.
+        print("No Local AI services will be started based on selection and profile. Supabase is running.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This commit introduces LiteLLM as a new optional service and provides a mechanism to selectively load Docker services.

Key changes:

- Added `litellm` service to `docker-compose.yml`.
    - Uses `ghcr.io/berriai/litellm:main-stable` image.
    - Exposes port 4000 internally.
    - Mounts a configuration file from `./litellm/config.yaml`.
    - Depends on `ollama` and `redis`.
- Created `litellm/config.yaml` with a default configuration to connect to a local Ollama model.
- Updated `Caddyfile` to include a reverse proxy for `litellm` (defaulting to port 8009).
- Modified `start_services.py`:
    - Added a `--services` command-line argument to specify a comma-separated list of services to start (e.g., `litellm,ollama,open-webui`).
    - If `--services` is not provided, all services are started by default.
    - Service dependencies are automatically resolved and started. For example, selecting `open-webui` will also start `ollama`. Selecting `litellm` will start `ollama` and `redis`.
    - The `supabase` services are always started.
    - The `caddy` service is automatically started if any other application services are selected.
- Updated `README.md` to:
    - Document the new `--services` flag and its usage.
    - List available services.
    - Explain how to configure `litellm` using `litellm/config.yaml`.
    - Provide details on accessing `litellm` via Caddy.