### PR TITLE
feat: Add option to use Podman Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,19 @@ Before running the services, you need to set up your environment variables for S
 
 The project includes a `start_services.py` script that handles starting both the Supabase and local AI services. The script accepts a `--profile` flag to specify which GPU configuration to use.
 
+### Using Podman Compose
+
+This project also supports Podman Compose as an alternative to Docker Compose. If you prefer to use Podman:
+
+1.  **Ensure Podman and Podman Compose are installed.** If you don't have them, you can find installation instructions on the [official Podman website](https://podman.io/getting-started/installation). Make sure `podman-compose` is installed, as this is what the script uses.
+2.  **Run `start_services.py` with the `--compose-command` flag:**
+
+    ```bash
+    python start_services.py --compose-command podman --profile <your-profile>
+    ```
+
+    Replace `<your-profile>` with your desired profile (e.g., `cpu`, `gpu-nvidia`). This will instruct the script to use `podman-compose` for all compose operations and `podman` for other container management commands.
+
 ### For Nvidia GPU users
 
 ```bash

--- a/start_services.py
+++ b/start_services.py
@@ -15,8 +15,20 @@ import argparse
 import platform
 import sys
 
+# Global variable for the compose command
+COMPOSE_COMMAND = "docker"
+
 def run_command(cmd, cwd=None):
     """Run a shell command and print it."""
+    # Replace "docker" with the selected compose command if it's a compose operation
+    if cmd[0] == "docker" and cmd[1] == "compose":
+        # For compose commands, use COMPOSE_COMMAND directly (e.g., "docker compose" or "podman-compose")
+        cmd = [COMPOSE_COMMAND] + cmd[1:]
+    elif cmd[0] == "docker":
+        # For other docker commands like ps, exec, use the base command (e.g., "docker" or "podman")
+        base_cmd = COMPOSE_COMMAND.split("-")[0]
+        cmd = [base_cmd] + cmd[1:]
+
     print("Running:", " ".join(cmd))
     subprocess.run(cmd, cwd=cwd, check=True)
 
@@ -214,7 +226,16 @@ def main():
     parser = argparse.ArgumentParser(description='Start the local AI and Supabase services.')
     parser.add_argument('--profile', choices=['cpu', 'gpu-nvidia', 'gpu-amd', 'none'], default='cpu',
                       help='Profile to use for Docker Compose (default: cpu)')
+    parser.add_argument('--compose-command', choices=['docker', 'podman'], default='docker',
+                        help='Compose command to use (docker or podman, default: docker)')
     args = parser.parse_args()
+
+    global COMPOSE_COMMAND
+    if args.compose_command == 'podman':
+        COMPOSE_COMMAND = "podman-compose" # Podman uses podman-compose
+    else:
+        COMPOSE_COMMAND = "docker"
+
 
     clone_supabase_repo()
     prepare_supabase_env()


### PR DESCRIPTION
This commit introduces support for Podman Compose as an alternative to Docker Compose for starting and managing services. This esse solution will minimize some security issue ( https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html)

Changes include:
- Modified `start_services.py` to include a `--compose-command` argument, allowing you to specify either `docker` or `podman`. The script now dynamically adjusts commands based on this selection.
- Updated `README.md` to document the new Podman Compose functionality, including installation instructions and usage examples.

This change addresses security concerns related to Docker and provides you with more flexibility in your choice of container management tools, as suggested in the OWASP Docker Security Cheat Sheet.