### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,13 @@ services:
       - 3001/tcp
     environment:
         - PORT=3001
-        - FLOWISE_USERNAME=${FLOWISE_USERNAME}
-        - FLOWISE_PASSWORD=${FLOWISE_PASSWORD}  
+        - JWT_AUTH_TOKEN_SECRET=${JWT_AUTH_TOKEN_SECRET}
+        - JWT_REFRESH_TOKEN_SECRET=${JWT_REFRESH_TOKEN_SECRET}
+        - JWT_TOKEN_EXPIRY_IN_MINUTES=60
+        - JWT_REFRESH_TOKEN_EXPIRY_IN_MINUTES=129600
+        - JWT_AUDIENCE=flowise
+        - JWT_ISSUER=flowise
+        - EXPRESS_SESSION_SECRET=${EXPRESS_SESSION_SECRET}
     extra_hosts:
       - "host.docker.internal:host-gateway"        
     volumes:


### PR DESCRIPTION
Flowise has made app auth deprecated. https://docs.flowiseai.com/configuration/authorization/application#username-and-password-deprecated

This is the simplest new way to just have a local account.