### PR TITLE
fix for when SearXNG settings.yml already exists

### DIFF
--- a/start_services.py
+++ b/start_services.py
@@ -101,6 +101,7 @@ def generate_searxng_secret_key():
             return
     else:
         print(f"SearXNG settings.yml already exists at {settings_path}")
+        return
 
     print("Generating SearXNG secret key...")
 


### PR DESCRIPTION
The current code executes a new pwsh shell everytime it was run and this caused issues for me, so I fixed so that when the settings.yml file already exists then just do noting.
