### PR TITLE
Add documentation for enabling n8n LocalFileTrigger node

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,10 @@ Here are solutions to common issues you might encounter:
 
 - **Linux GPU Support**: If you're having trouble running Ollama with GPU support on Linux, follow the [Ollama Docker instructions](https://github.com/ollama/ollama/blob/main/docs/docker.md).
 
+### n8n Node Issues
+
+- **Local File Trigger or Execute Command nodes not available**: Starting with n8n v2+, these nodes are disabled by default for security. To enable them, uncomment `NODES_EXCLUDE=[]` in the `x-n8n` section of `docker-compose.yml` and restart n8n. See [Accessing local files](#accessing-local-files) for detailed instructions.
+
 ## 👓 Recommended reading
 
 n8n is full of useful content for getting started quickly with its AI concepts
@@ -411,6 +415,26 @@ interact with the local filesystem.
 - [Read/Write Files from Disk](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.filesreadwrite/)
 - [Local File Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.localfiletrigger/)
 - [Execute Command](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.executecommand/)
+
+**Enabling Local File Trigger and Execute Command nodes**
+
+Starting with n8n v2+, the `Local File Trigger` and `Execute Command` nodes are disabled by default for security reasons. To enable them in this local/self-hosted environment:
+
+1. Open `docker-compose.yml`
+2. Find the `x-n8n` section and uncomment the `NODES_EXCLUDE` line:
+   ```yaml
+   x-n8n: &service-n8n
+     image: n8nio/n8n:latest
+     environment:
+       # ... other variables ...
+       - NODES_EXCLUDE=[]
+   ```
+3. Restart the n8n container:
+   ```bash
+   docker compose -p localai -f docker-compose.yml --profile <your-profile> up -d n8n
+   ```
+
+See [n8n 2.0 Breaking Changes](https://docs.n8n.io/2-0-breaking-changes/#disable-executecommand-and-localfiletrigger-nodes-by-default) for more details.
 
 ## 📜 License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,8 @@ x-n8n: &service-n8n
     - N8N_ENCRYPTION_KEY
     - N8N_USER_MANAGEMENT_JWT_SECRET
     - WEBHOOK_URL=${N8N_HOSTNAME:+https://}${N8N_HOSTNAME:-http://localhost:5678}
-    - NODES_EXCLUDE=[]
+    # Uncomment to enable LocalFileTrigger and ExecuteCommand nodes (disabled by default in n8n v2+)
+    # - NODES_EXCLUDE=[]
 
 x-ollama: &service-ollama
   image: ollama/ollama:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ x-n8n: &service-n8n
     - N8N_ENCRYPTION_KEY
     - N8N_USER_MANAGEMENT_JWT_SECRET
     - WEBHOOK_URL=${N8N_HOSTNAME:+https://}${N8N_HOSTNAME:-http://localhost:5678}
+    - NODES_EXCLUDE=[]
 
 x-ollama: &service-ollama
   image: ollama/ollama:latest


### PR DESCRIPTION
## Summary

- Added commented `NODES_EXCLUDE=[]` option in `docker-compose.yml` for users who need LocalFileTrigger/ExecuteCommand nodes
- Added documentation in README "Accessing local files" section explaining how to enable these nodes
- Added troubleshooting entry for users who can't find these nodes

## Context

n8n v2+ disables `LocalFileTrigger` and `ExecuteCommand` nodes by default for security reasons. This affects users following Module 3.7 RAG Prototype tutorials.

Rather than enabling by default, this PR documents the opt-in process so users understand they're making a conscious security decision.

## Test plan

- [ ] Verify commented line in docker-compose.yml doesn't break startup
- [ ] Verify uncommenting the line enables the nodes after restart

Fixes #181

🤖 Generated with [Claude Code](https://claude.ai/code)